### PR TITLE
added file ext checking

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@
 
 const YAML = require('yamljs')
 const { homedir } = require('os')
-const { join, dirname } = require('path')
+const { join, dirname, extname } = require('path')
 const crypto = require('crypto')
 const { file:fileHelp, obj:objHelp, collection } = require('./utils')
 
@@ -375,11 +375,16 @@ const _resolveTokenRef = ({ config, tokenRef, tokenRefs, optTokens, rootFolder }
 			const externalConfigPath = join(rootFolder, ref.file.path[0])
 			const [, ...props] = ref.file.path
 			const propsPath = props.join('.')
-			const externalConfig = _parse(externalConfigPath, optTokens)
-			if (!externalConfig)
-				throw new Error(`'file' with path ${externalConfigPath} located under ${dotPath} is empty.`)
+			const ext = extname(externalConfigPath);
+			if (['.yaml', '.yml'].indexOf(ext) > -1) {
+				const externalConfig = _parse(externalConfigPath, optTokens)
+				if (!externalConfig)
+					throw new Error(`'file' with path ${externalConfigPath} located under ${dotPath} is empty.`)
 
-			resolvedValue = propsPath ? objHelp.get(externalConfig, propsPath) : externalConfig
+				resolvedValue = propsPath ? objHelp.get(externalConfig, propsPath) : externalConfig
+			} else {
+				resolvedValue = fileHelp.read(externalConfigPath, { sync:true });
+			}
 		} else if (type == 'env') {
 			const envName = ((ref.env || {}).path || [])[0] || ''
 			const envValue = envName? process.env[envName] : ''


### PR DESCRIPTION
got an error of parsing yaml file in situation when one of parameter refers to the public key path. The parser tries to parse this file as yaml but it is not same behavior as SLS do. Sls reads such file 

AUTH0_CLIENT_PUBLIC_KEY: ${file('./some-public-key.pem')}   