### PR TITLE
fix: don't fail if value for token ref is not found, log warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -338,6 +338,12 @@ const _isPathResolved = (obj,prop) => {
 const _resolveTokenRef = ({ config, tokenRef, tokenRefs, optTokens, rootFolder }) => {
 	const { raw='', ref, dotPath='' } = tokenRef	// e.g., p: [ 'resources', 'Resources', 'UserTable', 'Properties', 'TableName' ], raw: 'user_${opt:custom.stage}'
 	const { type='', value } = ref || {}		// e.g., type: 'opt', value:'prod'
+
+	if (!ref[type]) {
+		console.warn(`sls-config-parser: unable to find value for ${tokenRef.dotPath}`);
+		return;
+	}
+
 	const defaultValue = ref[type].alt		// e.g., 'dev'
 	let resolvedValue = value 
 


### PR DESCRIPTION
Log a warning if a token is not found. This is similar to what serverless offline does when it cannot fill a variable.

I have issues when using `${AWS::AccountId}` with sls offline. This resolves that issue.